### PR TITLE
feat: parallel_tool_calls + tool_choice passthrough + workarounds module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ src/
 │   ├── traits.rs       # EmbeddingProvider, NliProvider, StanceProvider, etc.
 │   ├── registry.rs     # ProviderRegistry (fallback chains per capability)
 │   ├── llm_chat.rs     # LlmChatProvider wrapping llm crate (+ fetch_metadata for OpenRouter)
+│   ├── workarounds.rs  # Provider-specific parameter translation (parallel_tool_calls, extra_body)
 │   ├── openrouter_models.rs  # OpenRouter /api/v1/models response types + conversion
 │   ├── huggingface.rs  # HuggingFace Inference API client
 │   ├── fastembed.rs    # Local embeddings via fastembed-rs
@@ -106,7 +107,7 @@ contrib/
 - `ModelGateway` — async trait with `chat()`, `chat_stream()`, `embed()`, `infer_nli()`, `classify_stance()`, `model_metadata()`, `fetch_model_metadata()`, etc.
 - `Message` — role (System/User/Assistant/Tool) + content + optional tool_calls
 - `ChatEvent` — streaming events: Content, Reasoning, ToolCallStart, ToolCallDelta, Usage, Done
-- `ChatOptions` — model, temperature, max_tokens, top_k, reasoning config, tool_choice, etc.
+- `ChatOptions` — model, temperature, max_tokens, top_k, reasoning config, tool_choice, parallel_tool_calls, etc.
 - `GenerateOptions` — model, temperature, max_tokens, top_k, frequency/presence penalty, seed, reasoning
 - `RatatoskrError` — comprehensive error enum; `ModelNotAvailable` triggers fallback, `UnsupportedParameter` for validation errors
 - `StanceResult` — stance detection result (favor/against/neutral scores with label)
@@ -185,8 +186,9 @@ With the `server` and `client` features enabled:
 - `ParameterName` — hybrid enum with well-known params + `Custom(String)` for provider-specific options
 - `ParameterAvailability` — mutable (with range), read-only, opaque, or unsupported per parameter
 - `ParameterValidationPolicy` — opt-in validation (warn/error/ignore) when providers declare their supported params
-- `ChatOptions` and `GenerateOptions` at full parity: temperature, top_p, top_k, max_tokens, frequency/presence penalty, seed, reasoning
+- `ChatOptions` and `GenerateOptions` at full parity: temperature, top_p, top_k, max_tokens, frequency/presence penalty, seed, reasoning, parallel_tool_calls
 - `raw_provider_options` escape hatch for provider-specific JSON options
+- `workarounds` module isolates provider-specific parameter translation (e.g. `parallel_tool_calls` via `extra_body` for OpenAI-compatible backends, native flag for Mistral, `UnsupportedParameter` for Anthropic direct)
 - Proto `GetModelMetadata` + `FetchModelMetadata` RPCs for remote metadata queries via `ServiceClient`
 
 ## Testing Strategy

--- a/proto/ratatoskr.proto
+++ b/proto/ratatoskr.proto
@@ -111,6 +111,7 @@ message ChatOptions {
     optional uint32 top_k = 13;
     // Escape hatch: provider-specific options as JSON string.
     optional string raw_provider_options = 14;
+    optional bool parallel_tool_calls = 15;
 }
 
 message ToolChoice {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -9,6 +9,7 @@ pub mod llm_chat;
 pub(crate) mod openrouter_models;
 pub mod registry;
 pub mod traits;
+pub(crate) mod workarounds;
 
 #[cfg(feature = "local-inference")]
 pub mod fastembed;

--- a/src/providers/workarounds.rs
+++ b/src/providers/workarounds.rs
@@ -1,0 +1,174 @@
+//! Provider-specific translation layer for parameters that require
+//! backend-specific handling.
+//!
+//! All "this provider needs it *this* way" logic lives here and nowhere else.
+//! When the llm crate gains native support for these features, entries here
+//! can be removed without touching the rest of the codebase.
+
+use llm::builder::LLMBackend;
+use serde_json::{Map, Value};
+
+use crate::ChatOptions;
+use crate::error::{RatatoskrError, Result};
+
+/// Adjustments computed by the workarounds module for a specific
+/// backend + options combination.
+///
+/// Keeps provider-specific translation logic isolated from the
+/// main provider implementation.
+#[derive(Debug, Default)]
+pub(crate) struct ProviderAdjustments {
+    /// Extra fields to merge into the request body via `LLMBuilder::extra_body`.
+    /// Only works for backends with `#[serde(flatten)]` support (openai-compatible).
+    pub extra_body: Option<Value>,
+
+    /// Native parallel tool use flag (for backends like mistral where the
+    /// llm crate's `enable_parallel_tool_use` actually works).
+    pub native_parallel_tool_calls: Option<bool>,
+}
+
+/// Compute provider-specific adjustments for the given backend and options.
+///
+/// This is the single entry point for all workaround logic. The returned
+/// adjustments should be applied to the `LLMBuilder` in `build_provider()`.
+///
+/// # Errors
+///
+/// Returns `UnsupportedParameter` if a requested parameter cannot be
+/// supported by the target backend (e.g. `parallel_tool_calls` on
+/// anthropic direct).
+pub(crate) fn compute_adjustments(
+    backend: &LLMBackend,
+    options: &ChatOptions,
+) -> Result<ProviderAdjustments> {
+    let mut adj = ProviderAdjustments::default();
+
+    // start with raw_provider_options as base extra_body (if any)
+    let mut extra_map: Map<String, Value> = options
+        .raw_provider_options
+        .as_ref()
+        .and_then(|v: &Value| v.as_object().cloned())
+        .unwrap_or_default();
+
+    // parallel_tool_calls — backend-specific routing
+    if let Some(ptc) = options.parallel_tool_calls {
+        match backend {
+            LLMBackend::Mistral => {
+                adj.native_parallel_tool_calls = Some(ptc);
+            }
+            LLMBackend::OpenRouter | LLMBackend::OpenAI => {
+                extra_map.insert("parallel_tool_calls".into(), Value::Bool(ptc));
+            }
+            LLMBackend::Anthropic => {
+                return Err(RatatoskrError::UnsupportedParameter {
+                    param: "parallel_tool_calls".into(),
+                    model: options.model.clone(),
+                    provider: "anthropic".into(),
+                });
+            }
+            // google, ollama, deepseek, xai, etc. — silently ignore
+            _ => {}
+        }
+    }
+
+    // only set extra_body if we actually have entries
+    if !extra_map.is_empty() {
+        adj.extra_body = Some(Value::Object(extra_map));
+    }
+
+    Ok(adj)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_openrouter_parallel_true() {
+        let opts = ChatOptions::default()
+            .model("openai/gpt-4o")
+            .parallel_tool_calls(true);
+        let adj = compute_adjustments(&LLMBackend::OpenRouter, &opts).unwrap();
+        assert_eq!(
+            adj.extra_body.unwrap()["parallel_tool_calls"],
+            Value::Bool(true)
+        );
+        assert!(adj.native_parallel_tool_calls.is_none());
+    }
+
+    #[test]
+    fn test_openrouter_parallel_false() {
+        let opts = ChatOptions::default()
+            .model("openai/gpt-4o")
+            .parallel_tool_calls(false);
+        let adj = compute_adjustments(&LLMBackend::OpenRouter, &opts).unwrap();
+        assert_eq!(
+            adj.extra_body.unwrap()["parallel_tool_calls"],
+            Value::Bool(false)
+        );
+    }
+
+    #[test]
+    fn test_mistral_parallel_native() {
+        let opts = ChatOptions::default()
+            .model("mistral-large")
+            .parallel_tool_calls(true);
+        let adj = compute_adjustments(&LLMBackend::Mistral, &opts).unwrap();
+        assert_eq!(adj.native_parallel_tool_calls, Some(true));
+        assert!(adj.extra_body.is_none());
+    }
+
+    #[test]
+    fn test_anthropic_direct_errors() {
+        let opts = ChatOptions::default()
+            .model("claude-3.5-sonnet")
+            .parallel_tool_calls(false);
+        let err = compute_adjustments(&LLMBackend::Anthropic, &opts).unwrap_err();
+        assert!(
+            matches!(err, RatatoskrError::UnsupportedParameter { ref param, .. } if param == "parallel_tool_calls")
+        );
+    }
+
+    #[test]
+    fn test_google_ollama_ignored() {
+        for backend in [LLMBackend::Google, LLMBackend::Ollama] {
+            let opts = ChatOptions::default()
+                .model("test")
+                .parallel_tool_calls(true);
+            let adj = compute_adjustments(&backend, &opts).unwrap();
+            assert!(adj.extra_body.is_none());
+            assert!(adj.native_parallel_tool_calls.is_none());
+        }
+    }
+
+    #[test]
+    fn test_raw_provider_options_passthrough() {
+        let mut opts = ChatOptions::default().model("openai/gpt-4o");
+        opts.raw_provider_options = Some(json!({"custom_key": "custom_value"}));
+        let adj = compute_adjustments(&LLMBackend::OpenRouter, &opts).unwrap();
+        let extra = adj.extra_body.unwrap();
+        assert_eq!(extra["custom_key"], "custom_value");
+    }
+
+    #[test]
+    fn test_parallel_overrides_raw() {
+        let mut opts = ChatOptions::default()
+            .model("openai/gpt-4o")
+            .parallel_tool_calls(true);
+        opts.raw_provider_options = Some(json!({"parallel_tool_calls": false, "other": 42}));
+        let adj = compute_adjustments(&LLMBackend::OpenRouter, &opts).unwrap();
+        let extra = adj.extra_body.unwrap();
+        // typed field wins over raw
+        assert_eq!(extra["parallel_tool_calls"], Value::Bool(true));
+        assert_eq!(extra["other"], 42);
+    }
+
+    #[test]
+    fn test_no_options_no_adjustments() {
+        let opts = ChatOptions::default().model("gpt-4o");
+        let adj = compute_adjustments(&LLMBackend::OpenRouter, &opts).unwrap();
+        assert!(adj.extra_body.is_none());
+        assert!(adj.native_parallel_tool_calls.is_none());
+    }
+}

--- a/src/registry/seed.json
+++ b/src/registry/seed.json
@@ -13,7 +13,8 @@
       "top_k": { "availability": "mutable", "range": { "min": 1.0 } },
       "max_tokens": { "availability": "mutable", "range": { "min": 1.0, "max": 16384.0 } },
       "stop": { "availability": "mutable", "range": {} },
-      "reasoning": { "availability": "mutable", "range": {} }
+      "reasoning": { "availability": "mutable", "range": {} },
+      "parallel_tool_calls": { "availability": "mutable", "range": {} }
     },
     "pricing": { "prompt_cost_per_mtok": 3.0, "completion_cost_per_mtok": 15.0 },
     "max_output_tokens": 16384
@@ -30,7 +31,8 @@
       "temperature": { "availability": "mutable", "range": { "min": 0.0, "max": 1.0, "default": 1.0 } },
       "top_p": { "availability": "mutable", "range": { "min": 0.0, "max": 1.0 } },
       "top_k": { "availability": "mutable", "range": { "min": 1.0 } },
-      "max_tokens": { "availability": "mutable", "range": { "min": 1.0, "max": 8192.0 } }
+      "max_tokens": { "availability": "mutable", "range": { "min": 1.0, "max": 8192.0 } },
+      "parallel_tool_calls": { "availability": "mutable", "range": {} }
     },
     "pricing": { "prompt_cost_per_mtok": 0.80, "completion_cost_per_mtok": 4.0 },
     "max_output_tokens": 8192
@@ -49,7 +51,8 @@
       "frequency_penalty": { "availability": "mutable", "range": { "min": -2.0, "max": 2.0, "default": 0.0 } },
       "presence_penalty": { "availability": "mutable", "range": { "min": -2.0, "max": 2.0, "default": 0.0 } },
       "max_tokens": { "availability": "mutable", "range": { "min": 1.0, "max": 16384.0 } },
-      "seed": { "availability": "mutable", "range": {} }
+      "seed": { "availability": "mutable", "range": {} },
+      "parallel_tool_calls": { "availability": "mutable", "range": {} }
     },
     "pricing": { "prompt_cost_per_mtok": 2.50, "completion_cost_per_mtok": 10.0 },
     "max_output_tokens": 16384

--- a/src/server/convert.rs
+++ b/src/server/convert.rs
@@ -85,6 +85,7 @@ impl From<proto::ChatOptions> for ChatOptions {
             response_format: p.response_format.map(Into::into),
             cache_prompt: p.cache_prompt,
             reasoning: p.reasoning.map(Into::into),
+            parallel_tool_calls: p.parallel_tool_calls,
             raw_provider_options: p
                 .raw_provider_options
                 .and_then(|s| serde_json::from_str(&s).ok()),
@@ -774,6 +775,7 @@ impl From<ChatOptions> for proto::ChatOptions {
                 max_tokens: r.max_tokens.map(|t| t as u32),
                 exclude_from_output: r.exclude_from_output,
             }),
+            parallel_tool_calls: o.parallel_tool_calls,
             raw_provider_options: o
                 .raw_provider_options
                 .and_then(|v| serde_json::to_string(&v).ok()),

--- a/src/types/options.rs
+++ b/src/types/options.rs
@@ -27,6 +27,8 @@ pub struct ChatOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub parallel_tool_calls: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub response_format: Option<ResponseFormat>,
 
     // Normalized cross-provider options
@@ -91,6 +93,11 @@ impl ChatOptions {
         self
     }
 
+    pub fn parallel_tool_calls(mut self, enabled: bool) -> Self {
+        self.parallel_tool_calls = Some(enabled);
+        self
+    }
+
     pub fn response_format(mut self, format: ResponseFormat) -> Self {
         self.response_format = Some(format);
         self
@@ -137,6 +144,9 @@ impl ChatOptions {
         }
         if self.tool_choice.is_some() {
             params.push(ParameterName::ToolChoice);
+        }
+        if self.parallel_tool_calls.is_some() {
+            params.push(ParameterName::ParallelToolCalls);
         }
         if self.response_format.is_some() {
             params.push(ParameterName::ResponseFormat);

--- a/src/types/parameter.rs
+++ b/src/types/parameter.rs
@@ -30,6 +30,7 @@ pub enum ParameterName {
     CachePrompt,
     ResponseFormat,
     ToolChoice,
+    ParallelToolCalls,
     /// Provider-specific parameter not in the well-known set.
     Custom(String),
 }
@@ -50,6 +51,7 @@ impl ParameterName {
             Self::CachePrompt => "cache_prompt",
             Self::ResponseFormat => "response_format",
             Self::ToolChoice => "tool_choice",
+            Self::ParallelToolCalls => "parallel_tool_calls",
             Self::Custom(s) => s.as_str(),
         }
     }
@@ -78,6 +80,7 @@ impl FromStr for ParameterName {
             "cache_prompt" => Self::CachePrompt,
             "response_format" => Self::ResponseFormat,
             "tool_choice" => Self::ToolChoice,
+            "parallel_tool_calls" => Self::ParallelToolCalls,
             other => Self::Custom(other.to_string()),
         })
     }

--- a/tests/convert_test.rs
+++ b/tests/convert_test.rs
@@ -28,13 +28,17 @@ fn test_tool_definition_roundtrip() {
 
 #[test]
 fn test_chat_options_roundtrip() {
-    let opts = ChatOptions::default().model("gpt-4").temperature(0.7);
+    let opts = ChatOptions::default()
+        .model("gpt-4")
+        .temperature(0.7)
+        .parallel_tool_calls(false);
 
     let json = serde_json::to_string(&opts).unwrap();
     let parsed: ChatOptions = serde_json::from_str(&json).unwrap();
 
     assert_eq!(parsed.model, "gpt-4");
     assert_eq!(parsed.temperature, Some(0.7));
+    assert_eq!(parsed.parallel_tool_calls, Some(false));
 }
 
 // ===== Phase 6: ModelMetadata proto roundtrip =====

--- a/tests/options_test.rs
+++ b/tests/options_test.rs
@@ -1,4 +1,4 @@
-use ratatoskr::{ChatOptions, ReasoningConfig, ReasoningEffort, ResponseFormat};
+use ratatoskr::{ChatOptions, ParameterName, ReasoningConfig, ReasoningEffort, ResponseFormat};
 
 #[test]
 fn test_chat_options_top_k() {
@@ -49,4 +49,37 @@ fn test_response_format_variants() {
     let json_obj = ResponseFormat::JsonObject;
     assert!(matches!(text, ResponseFormat::Text));
     assert!(matches!(json_obj, ResponseFormat::JsonObject));
+}
+
+#[test]
+fn test_chat_options_parallel_tool_calls_builder() {
+    let opts = ChatOptions::default()
+        .model("gpt-4o")
+        .parallel_tool_calls(false);
+    assert_eq!(opts.parallel_tool_calls, Some(false));
+}
+
+#[test]
+fn test_chat_options_parallel_tool_calls_serde() {
+    let opts = ChatOptions::default()
+        .model("gpt-4o")
+        .parallel_tool_calls(true);
+    let json = serde_json::to_string(&opts).unwrap();
+    assert!(json.contains("\"parallel_tool_calls\":true"));
+    let parsed: ChatOptions = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.parallel_tool_calls, Some(true));
+}
+
+#[test]
+fn test_chat_options_parallel_tool_calls_in_set_parameters() {
+    let opts = ChatOptions::default()
+        .model("gpt-4o")
+        .parallel_tool_calls(true);
+    let params = opts.set_parameters();
+    assert!(params.contains(&ParameterName::ParallelToolCalls));
+
+    // absent when not set
+    let opts_none = ChatOptions::default().model("gpt-4o");
+    let params_none = opts_none.set_parameters();
+    assert!(!params_none.contains(&ParameterName::ParallelToolCalls));
 }

--- a/tests/parameter_test.rs
+++ b/tests/parameter_test.rs
@@ -17,6 +17,10 @@ fn well_known_parameter_names() {
     assert_eq!(ParameterName::CachePrompt.as_str(), "cache_prompt");
     assert_eq!(ParameterName::ResponseFormat.as_str(), "response_format");
     assert_eq!(ParameterName::ToolChoice.as_str(), "tool_choice");
+    assert_eq!(
+        ParameterName::ParallelToolCalls.as_str(),
+        "parallel_tool_calls"
+    );
 }
 
 #[test]
@@ -39,12 +43,17 @@ fn parameter_name_from_str() {
         "logit_bias".parse::<ParameterName>().unwrap(),
         ParameterName::Custom("logit_bias".into())
     );
+    assert_eq!(
+        "parallel_tool_calls".parse::<ParameterName>().unwrap(),
+        ParameterName::ParallelToolCalls
+    );
 }
 
 #[test]
 fn parameter_name_serde_roundtrip() {
     let names = vec![
         ParameterName::Temperature,
+        ParameterName::ParallelToolCalls,
         ParameterName::Custom("logit_bias".into()),
     ];
     let json = serde_json::to_string(&names).unwrap();

--- a/tests/tool_test.rs
+++ b/tests/tool_test.rs
@@ -51,3 +51,34 @@ fn test_tool_choice_default() {
     let choice = ToolChoice::default();
     assert!(matches!(choice, ToolChoice::Auto));
 }
+
+#[test]
+fn test_tool_choice_variants_serde() {
+    let variants = vec![
+        (ToolChoice::Auto, "\"auto\""),
+        (ToolChoice::None, "\"none\""),
+        (ToolChoice::Required, "\"required\""),
+    ];
+    for (variant, expected) in variants {
+        let json = serde_json::to_string(&variant).unwrap();
+        assert_eq!(json, expected);
+        let parsed: ToolChoice = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            std::mem::discriminant(&parsed),
+            std::mem::discriminant(&variant)
+        );
+    }
+}
+
+#[test]
+fn test_tool_choice_function_serde() {
+    let tc = ToolChoice::Function {
+        name: "get_weather".into(),
+    };
+    let json = serde_json::to_string(&tc).unwrap();
+    let parsed: ToolChoice = serde_json::from_str(&json).unwrap();
+    match parsed {
+        ToolChoice::Function { name } => assert_eq!(name, "get_weather"),
+        other => panic!("expected Function, got {other:?}"),
+    }
+}


### PR DESCRIPTION
add parallel_tool_calls field to ChatOptions with full pipeline support
(types, proto, convert, seed data). fix two pre-existing bugs: tool_choice
and raw_provider_options were silently dropped in build_provider().

introduce src/providers/workarounds.rs to isolate provider-specific
parameter translation — openai-compatible backends get extra_body,
mistral gets native flag, anthropic direct returns UnsupportedParameter.
