### PR TITLE
fix: map ToolUseComplete to ToolCallEnd instead of Done (#16)

### DIFF
--- a/proto/ratatoskr.proto
+++ b/proto/ratatoskr.proto
@@ -170,6 +170,7 @@ message ChatEvent {
         ToolCallDelta tool_call_delta = 4;
         Usage usage = 5;
         bool done = 6;
+        ToolCallEnd tool_call_end = 7;
     }
 }
 
@@ -182,6 +183,10 @@ message ToolCallStart {
 message ToolCallDelta {
     uint32 index = 1;
     string arguments = 2;
+}
+
+message ToolCallEnd {
+    uint32 index = 1;
 }
 
 // =============================================================================

--- a/src/providers/llm_chat.rs
+++ b/src/providers/llm_chat.rs
@@ -313,9 +313,8 @@ impl ChatProvider for LlmChatProvider {
                         index,
                         arguments: partial_json,
                     },
-                    llm::chat::StreamChunk::ToolUseComplete { .. } => {
-                        // Emit Done to signal tool completion
-                        ChatEvent::Done
+                    llm::chat::StreamChunk::ToolUseComplete { index, .. } => {
+                        ChatEvent::ToolCallEnd { index }
                     }
                     llm::chat::StreamChunk::Done { .. } => ChatEvent::Done,
                 })

--- a/src/server/convert.rs
+++ b/src/server/convert.rs
@@ -246,6 +246,11 @@ impl From<ChatEvent> for proto::ChatEvent {
                     arguments,
                 })
             }
+            ChatEvent::ToolCallEnd { index } => {
+                proto::chat_event::Event::ToolCallEnd(proto::ToolCallEnd {
+                    index: index as u32,
+                })
+            }
             ChatEvent::Usage(u) => proto::chat_event::Event::Usage(u.into()),
             ChatEvent::Done => proto::chat_event::Event::Done(true),
         };
@@ -486,6 +491,9 @@ impl From<proto::ChatEvent> for ChatEvent {
             Some(proto::chat_event::Event::ToolCallDelta(t)) => ChatEvent::ToolCallDelta {
                 index: t.index as usize,
                 arguments: t.arguments,
+            },
+            Some(proto::chat_event::Event::ToolCallEnd(t)) => ChatEvent::ToolCallEnd {
+                index: t.index as usize,
             },
             Some(proto::chat_event::Event::Usage(u)) => ChatEvent::Usage(u.into()),
             Some(proto::chat_event::Event::Done(_)) | None => ChatEvent::Done,

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -38,6 +38,9 @@ pub enum ChatEvent {
     /// Incremental tool call arguments
     ToolCallDelta { index: usize, arguments: String },
 
+    /// A tool call's arguments are complete (does NOT end the stream)
+    ToolCallEnd { index: usize },
+
     /// Usage statistics (typically at end of stream)
     Usage(Usage),
 

--- a/tests/response_test.rs
+++ b/tests/response_test.rs
@@ -23,6 +23,9 @@ fn test_chat_event_variants() {
     let content = ChatEvent::Content("hello".into());
     assert!(matches!(content, ChatEvent::Content(_)));
 
+    let tool_call_end = ChatEvent::ToolCallEnd { index: 0 };
+    assert!(matches!(tool_call_end, ChatEvent::ToolCallEnd { index: 0 }));
+
     let done = ChatEvent::Done;
     assert!(matches!(done, ChatEvent::Done));
 }


### PR DESCRIPTION
ToolUseComplete was emitting ChatEvent::Done, causing consumers to
stop reading the stream after the first tool call — breaking parallel
and sequential multi-tool responses. Now emits ToolCallEnd { index }
so only StreamChunk::Done terminates the stream.

fixed #16